### PR TITLE
Add setup instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To set up the tezos-client, follow the instructions in the [Setup Tezos Client](
 #### Stack -v 1.9.3
 This project requires `stack@1.9.3` (newer versions have a known bug). You can install this version of `stack` from their [github repo](https://github.com/commercialhaskell/stack/releases/tag/v1.9.3). You may find the instructions [here](https://docs.haskellstack.org/en/stable/install_and_upgrade/#install-older-versions) helpful, though they are written with windows operating system in mind. 
 
-You can add the stack executable to your path if you want to access it as a global command (i.e. `stack --version`) or you can provide a path to the executable when you call it (e.g. `~/Downloads/stack --version`)
+You can [add the stack executable to your path](https://docs.haskellstack.org/en/stable/install_and_upgrade/#path) if you want to access it as a global command (i.e. `stack --version`) or you can provide a path to the executable when you call it (e.g. `~/Downloads/stack --version`)
 
 ### Installing Dependencies
 `stack build` Note that this will take some time. 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ See the FA1.2 [Quick Start Tutorial](https://assets.tqtezos.com/token-contracts/
 To set up the tezos-client, follow the instructions in the [Setup Tezos Client](https://assets.tqtezos.com/setup/1-tezos-client) tutorial
 
 #### Stack -v 1.9.3
-This project requires `stack@1.9.3` (newer versions have a known bug). You can install older versions of `stack` following the instructions [here](https://docs.haskellstack.org/en/stable/install_and_upgrade/#install-older-versions) 
+This project requires `stack@1.9.3` (newer versions have a known bug). You can install this version of `stack` from their [github repo](https://github.com/commercialhaskell/stack/releases/tag/v1.9.3). You may find the instructions [here](https://docs.haskellstack.org/en/stable/install_and_upgrade/#install-older-versions) helpful, though they are written with windows operating system in mind. 
+
+You can add the stack executable to your path if you want to access it as a global command (i.e. `stack --version`) or you can provide a path to the executable when you call it (e.g. `~/Downloads/stack --version`)
 
 ### Installing Dependencies
 `stack build` Note that this will take some time. 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 
 See the FA1.2 [Quick Start Tutorial](https://assets.tqtezos.com/token-contracts/1-fa12-lorentz) for more detail.
 
-See [here](README_SPECIALIZED.md) for the specalized multisig.
+## Setting Up
+### Requirements
+#### Tezos-client
+To set up the tezos-client, follow the instructions in the [Setup Tezos Client](https://assets.tqtezos.com/setup/1-tezos-client) tutorial
 
+#### Stack -v 1.9.3
+This project requires `stack@1.9.3` (newer versions have a known bug). You can install older versions of `stack` following the instructions [here](https://docs.haskellstack.org/en/stable/install_and_upgrade/#install-older-versions) 
+
+### Installing Dependencies
+`stack build` Note that this will take some time. 
+
+## Multisig
+See [here](README_SPECIALIZED.md) for the specalized multisig. Note that all commands in the readme are run from the root of the project.


### PR DESCRIPTION
One thing is that the setup puts stack in your global path. The multisig readme assumes you installed stack in the actual repo folder, which I feel eh about