### PR TITLE
Reject tez

### DIFF
--- a/README_ADMIN_42.md
+++ b/README_ADMIN_42.md
@@ -1,0 +1,138 @@
+
+## Admin42 Contract
+
+The `admin_42.tz` accepts a `nat` parameter (which must be `42`), only from the address in storage.
+This is a good contract to test the specialized multisig.
+
+```bash
+❯❯❯ tezos-client --wait none originate contract Admin42 \
+  transferring 0 from $BOB_ADDRESS running \
+  "$(cat admin_42.tz | tr '\n' ' ')" --init "\"$BOB_ADDRESS\"" --burn-cap 0.406
+```
+
+```bash
+❯❯❯ ADMIN42_ADDRESS="KT1LrmhejxwKB1mXiRyi9Bun5qRvBv6BUQvm"
+```
+
+Valid call:
+
+```bash
+❯❯❯ tezos-client --wait none transfer 0 from $BOB_ADDRESS to $ADMIN42_ADDRESS --arg 42 --burn-cap 0.000001
+
+Waiting for the node to be bootstrapped before injection...
+Current head: BLUy1hNv2rcX (timestamp: 2020-01-31T18:54:06-00:00, validation: 2020-01-31T18:54:40-00:00)
+Node is bootstrapped, ready for injecting operations.
+Estimated gas: 13781 units (will add 100 for safety)
+Estimated storage: no bytes added
+Operation successfully injected in the node.
+Operation hash is 'ooKBnZDrCf8GDp2LoQGp2KxSQMLB2JKKEkvSNGdPKVeH7RcKvNh'
+NOT waiting for the operation to be included.
+Use command
+  tezos-client wait for ooKBnZDrCf8GDp2LoQGp2KxSQMLB2JKKEkvSNGdPKVeH7RcKvNh to be included --confirmations 30 --branch BLYeCgYQjCnebgfJUhocMfRchuFAJx9rouLYeKt17wkuubKoG2a
+and/or an external block explorer to make sure that it has been included.
+This sequence of operations was run:
+  Manager signed operations:
+    From: tz1bDCu64RmcpWahdn9bWrDMi6cu7mXZynHm
+    Fee to the baker: ꜩ0.001646
+    Expected counter: 33116
+    Gas limit: 13881
+    Storage limit: 0 bytes
+    Balance updates:
+      tz1bDCu64RmcpWahdn9bWrDMi6cu7mXZynHm ............. -ꜩ0.001646
+      fees(tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU,123) ... +ꜩ0.001646
+    Transaction:
+      Amount: ꜩ0
+      From: tz1bDCu64RmcpWahdn9bWrDMi6cu7mXZynHm
+      To: KT1LrmhejxwKB1mXiRyi9Bun5qRvBv6BUQvm
+      Parameter: 42
+      This transaction was successfully applied
+      Updated storage: 0x0000aad02222472cdf9892a3011c01caf6407f027081
+      Storage size: 149 bytes
+      Consumed gas: 13781
+```
+
+Invalid call (wrong argument):
+
+```bash
+❯❯❯ tezos-client --wait none transfer 0 from $BOB_ADDRESS to $ADMIN42_ADDRESS --arg 43 --burn-cap 0.000001
+
+Waiting for the node to be bootstrapped before injection...
+Current head: BLYeCgYQjCne (timestamp: 2020-01-31T18:54:36-00:00, validation: 2020-01-31T18:54:56-00:00)
+Node is bootstrapped, ready for injecting operations.
+This simulation failed:
+  Manager signed operations:
+    From: tz1bDCu64RmcpWahdn9bWrDMi6cu7mXZynHm
+    Fee to the baker: ꜩ0
+    Expected counter: 33116
+    Gas limit: 800000
+    Storage limit: 60000 bytes
+    Transaction:
+      Amount: ꜩ0
+      From: tz1bDCu64RmcpWahdn9bWrDMi6cu7mXZynHm
+      To: KT1LrmhejxwKB1mXiRyi9Bun5qRvBv6BUQvm
+      Parameter: 43
+      This operation FAILED.
+
+Runtime error in contract KT1LrmhejxwKB1mXiRyi9Bun5qRvBv6BUQvm:
+  01: { parameter nat ;
+  02:   storage address ;
+  03:   code { DUP ;
+  04:          CDR ;
+  05:          SENDER ;
+  06:          ASSERT_CMPEQ ;
+  07:          DUP ;
+  08:          CAR ;
+  09:          PUSH nat 42 ;
+  10:          ASSERT_CMPEQ ;
+  11:          CDR ;
+  12:          NIL operation ;
+  13:          PAIR } }
+At line 10 characters 9 to 21,
+script reached FAILWITH instruction
+with Unit
+Fatal error:
+  transfer simulation failed
+```
+
+Invalid call (wrong user):
+
+```bash
+❯❯❯ tezos-client --wait none transfer 0 from $ALICE_ADDRESS to $ADMIN42_ADDRESS --arg 42 --burn-cap 0.000001
+
+Waiting for the node to be bootstrapped before injection...
+Current head: BKvAECjia3c4 (timestamp: 2020-02-03T19:06:18-00:00, validation: 2020-02-03T19:06:31-00:00)
+Node is bootstrapped, ready for injecting operations.
+This simulation failed:
+  Manager signed operations:
+    From: tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr
+    Fee to the baker: ꜩ0
+    Expected counter: 125197
+    Gas limit: 800000
+    Storage limit: 60000 bytes
+    Transaction:
+      Amount: ꜩ0
+      From: tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr
+      To: KT1LrmhejxwKB1mXiRyi9Bun5qRvBv6BUQvm
+      Parameter: 42
+      This operation FAILED.
+
+Runtime error in contract KT1LrmhejxwKB1mXiRyi9Bun5qRvBv6BUQvm:
+  01: { parameter nat ;
+  02:   storage address ;
+  03:   code { DUP ;
+  04:          CDR ;
+  05:          SENDER ;
+  06:          ASSERT_CMPEQ ;
+  07:          DUP ;
+  08:          CAR ;
+  09:          PUSH nat 42 ;
+  10:          ASSERT_CMPEQ ;
+  11:          CDR ;
+  12:          NIL operation ;
+  13:          PAIR } }
+At line 6 characters 9 to 21,
+script reached FAILWITH instruction
+with Unit
+Fatal error:
+  transfer simulation failed
+```

--- a/README_SPECIALIZED.md
+++ b/README_SPECIALIZED.md
@@ -1,7 +1,7 @@
 
 # Originated Example
 
-You can find an originated example [here](https://better-call.dev/babylon/KT1HmDgVFNM1t9sSYdURzUXWLUhb6AMyNxFW/operations).
+You can find an originated example, of a version that accepts and locks Tez [here](https://better-call.dev/babylon/KT1HmDgVFNM1t9sSYdURzUXWLUhb6AMyNxFW/operations).
 
 ## Specialized Multisig Contract
 
@@ -377,3 +377,4 @@ This sequence of operations was run:
         Storage size: 149 bytes
         Consumed gas: 13782
 ```
+

--- a/README_SPECIALIZED.md
+++ b/README_SPECIALIZED.md
@@ -32,7 +32,6 @@ storage (pair nat
                     (list key)));
 ```
 
-
 ### Printing the contract
 
 To print the contract, specialized to `nat`:
@@ -69,6 +68,9 @@ threshold is greater than the number of signer keys
 CallStack (from HasCallStack):
   error, called at src/Lorentz/Contracts/GenericMultisig/CmdLnArgs.hs:376:13 in lorentz-contract-multisig-0.1.0.0-BUWXHalK6PtIEryQAwm6u2:Lorentz.Contracts.GenericMultisig.CmdLnArgs
 ```
+
+DISCLAIMER: the examples that follow use a version of the specialized multisig that
+has a `(unit %default)` parameter that locks Tez.
 
 ```bash
 ❯❯❯ tezos-client --wait none originate contract MultisigNat \

--- a/README_SPECIALIZED.md
+++ b/README_SPECIALIZED.md
@@ -3,145 +3,6 @@
 
 You can find an originated example [here](https://better-call.dev/babylon/KT1HmDgVFNM1t9sSYdURzUXWLUhb6AMyNxFW/operations).
 
-
-## Admin42 Contract
-
-The `admin_42.tz` accepts a `nat` parameter (which must be `42`), only from the address in storage.
-This is a good contract to test the specialized multisig.
-
-```bash
-❯❯❯ tezos-client --wait none originate contract Admin42 \
-  transferring 0 from $BOB_ADDRESS running \
-  "$(cat admin_42.tz | tr '\n' ' ')" --init "\"$BOB_ADDRESS\"" --burn-cap 0.406
-```
-
-```bash
-❯❯❯ ADMIN42_ADDRESS="KT1LrmhejxwKB1mXiRyi9Bun5qRvBv6BUQvm"
-```
-
-Valid call:
-
-```bash
-❯❯❯ tezos-client --wait none transfer 0 from $BOB_ADDRESS to $ADMIN42_ADDRESS --arg 42 --burn-cap 0.000001
-
-Waiting for the node to be bootstrapped before injection...
-Current head: BLUy1hNv2rcX (timestamp: 2020-01-31T18:54:06-00:00, validation: 2020-01-31T18:54:40-00:00)
-Node is bootstrapped, ready for injecting operations.
-Estimated gas: 13781 units (will add 100 for safety)
-Estimated storage: no bytes added
-Operation successfully injected in the node.
-Operation hash is 'ooKBnZDrCf8GDp2LoQGp2KxSQMLB2JKKEkvSNGdPKVeH7RcKvNh'
-NOT waiting for the operation to be included.
-Use command
-  tezos-client wait for ooKBnZDrCf8GDp2LoQGp2KxSQMLB2JKKEkvSNGdPKVeH7RcKvNh to be included --confirmations 30 --branch BLYeCgYQjCnebgfJUhocMfRchuFAJx9rouLYeKt17wkuubKoG2a
-and/or an external block explorer to make sure that it has been included.
-This sequence of operations was run:
-  Manager signed operations:
-    From: tz1bDCu64RmcpWahdn9bWrDMi6cu7mXZynHm
-    Fee to the baker: ꜩ0.001646
-    Expected counter: 33116
-    Gas limit: 13881
-    Storage limit: 0 bytes
-    Balance updates:
-      tz1bDCu64RmcpWahdn9bWrDMi6cu7mXZynHm ............. -ꜩ0.001646
-      fees(tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU,123) ... +ꜩ0.001646
-    Transaction:
-      Amount: ꜩ0
-      From: tz1bDCu64RmcpWahdn9bWrDMi6cu7mXZynHm
-      To: KT1LrmhejxwKB1mXiRyi9Bun5qRvBv6BUQvm
-      Parameter: 42
-      This transaction was successfully applied
-      Updated storage: 0x0000aad02222472cdf9892a3011c01caf6407f027081
-      Storage size: 149 bytes
-      Consumed gas: 13781
-```
-
-Invalid call (wrong argument):
-
-```bash
-❯❯❯ tezos-client --wait none transfer 0 from $BOB_ADDRESS to $ADMIN42_ADDRESS --arg 43 --burn-cap 0.000001
-
-Waiting for the node to be bootstrapped before injection...
-Current head: BLYeCgYQjCne (timestamp: 2020-01-31T18:54:36-00:00, validation: 2020-01-31T18:54:56-00:00)
-Node is bootstrapped, ready for injecting operations.
-This simulation failed:
-  Manager signed operations:
-    From: tz1bDCu64RmcpWahdn9bWrDMi6cu7mXZynHm
-    Fee to the baker: ꜩ0
-    Expected counter: 33116
-    Gas limit: 800000
-    Storage limit: 60000 bytes
-    Transaction:
-      Amount: ꜩ0
-      From: tz1bDCu64RmcpWahdn9bWrDMi6cu7mXZynHm
-      To: KT1LrmhejxwKB1mXiRyi9Bun5qRvBv6BUQvm
-      Parameter: 43
-      This operation FAILED.
-
-Runtime error in contract KT1LrmhejxwKB1mXiRyi9Bun5qRvBv6BUQvm:
-  01: { parameter nat ;
-  02:   storage address ;
-  03:   code { DUP ;
-  04:          CDR ;
-  05:          SENDER ;
-  06:          ASSERT_CMPEQ ;
-  07:          DUP ;
-  08:          CAR ;
-  09:          PUSH nat 42 ;
-  10:          ASSERT_CMPEQ ;
-  11:          CDR ;
-  12:          NIL operation ;
-  13:          PAIR } }
-At line 10 characters 9 to 21,
-script reached FAILWITH instruction
-with Unit
-Fatal error:
-  transfer simulation failed
-```
-
-Invalid call (wrong user):
-
-```bash
-❯❯❯ tezos-client --wait none transfer 0 from $ALICE_ADDRESS to $ADMIN42_ADDRESS --arg 42 --burn-cap 0.000001
-
-Waiting for the node to be bootstrapped before injection...
-Current head: BKvAECjia3c4 (timestamp: 2020-02-03T19:06:18-00:00, validation: 2020-02-03T19:06:31-00:00)
-Node is bootstrapped, ready for injecting operations.
-This simulation failed:
-  Manager signed operations:
-    From: tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr
-    Fee to the baker: ꜩ0
-    Expected counter: 125197
-    Gas limit: 800000
-    Storage limit: 60000 bytes
-    Transaction:
-      Amount: ꜩ0
-      From: tz1R3vJ5TV8Y5pVj8dicBR23Zv8JArusDkYr
-      To: KT1LrmhejxwKB1mXiRyi9Bun5qRvBv6BUQvm
-      Parameter: 42
-      This operation FAILED.
-
-Runtime error in contract KT1LrmhejxwKB1mXiRyi9Bun5qRvBv6BUQvm:
-  01: { parameter nat ;
-  02:   storage address ;
-  03:   code { DUP ;
-  04:          CDR ;
-  05:          SENDER ;
-  06:          ASSERT_CMPEQ ;
-  07:          DUP ;
-  08:          CAR ;
-  09:          PUSH nat 42 ;
-  10:          ASSERT_CMPEQ ;
-  11:          CDR ;
-  12:          NIL operation ;
-  13:          PAIR } }
-At line 6 characters 9 to 21,
-script reached FAILWITH instruction
-with Unit
-Fatal error:
-  transfer simulation failed
-```
-
 ## Specialized Multisig Contract
 
 The specialized multisig contract is a variant of the generic multisig contract where:
@@ -349,6 +210,8 @@ MULTISIG_NAT_ADDRESS="KT1TT1KY7MgfD3RNfj2zufn7uNTXx7PNTrFg"
 ```
 
 Next, we originate a copy of the `admin_42` contract where the `MultisigNat` contract is the "admin":
+
+See [README_ADMIN_42.md](README_ADMIN_42.md) for the `admin_42` contract.
 
 ```bash
 ❯❯❯ tezos-client --wait none originate contract MultisigAdmin42 \

--- a/README_SPECIALIZED.md
+++ b/README_SPECIALIZED.md
@@ -144,6 +144,17 @@ Fatal error:
 
 ## Specialized Multisig Contract
 
+The specialized multisig contract is a variant of the generic multisig contract where:
+- Tez may not be sent to the contract
+- Only one parameter type may be signed and sent to the contract
+
+Unless you're changing the keys/threshold, you sign and send:
+  * A value of the specialized parameter's type
+  * A target contract address, whose entrypoint matches the specialized parameter's type
+  * The signatures
+The contract will check the signatures, increment the counter, and call the 
+target contract with the given parameter value.
+
 To print the contract, specialized to `nat`:
 
 ```bash

--- a/README_SPECIALIZED.md
+++ b/README_SPECIALIZED.md
@@ -155,6 +155,25 @@ Unless you're changing the keys/threshold, you sign and send:
 The contract will check the signatures, increment the counter, and call the 
 target contract with the given parameter value.
 
+
+### Parameter and storage types
+
+```
+parameter (pair (pair nat
+                      (or (pair nat
+                                (contract nat))
+                          (pair nat
+                                (list key))))
+                (list (option signature)));
+
+storage (pair nat
+              (pair nat
+                    (list key)));
+```
+
+
+### Printing the contract
+
 To print the contract, specialized to `nat`:
 
 ```bash

--- a/src/Lorentz/Contracts/GenericMultisig.hs
+++ b/src/Lorentz/Contracts/GenericMultisig.hs
@@ -48,7 +48,7 @@ assertNoTokensSent = do
   --   # Assert no token was sent:
   --   # to send tokens, the default entry point should be used
   --   PUSH mutez 0 ; AMOUNT ; ASSERT_CMPEQ ;
-  let tokensSentOutsideDefault = [mt|Some tokens were sent to this contract outside of the default entry point.|]
+  let tokensSentOutsideDefault = [mt|Some tokens were sent to this contract outside of a unit entry point.|]
   push (toMutez 0 :: Mutez) >> amount >> assertEq tokensSentOutsideDefault
 
 -- | Pair the payload with the current contract address, to ensure signatures

--- a/src/Lorentz/Contracts/GenericMultisig/CmdLnArgs.hs
+++ b/src/Lorentz/Contracts/GenericMultisig/CmdLnArgs.hs
@@ -54,7 +54,7 @@ packer :: forall key a p. (IsKey key, NicePackedValue a, NiceParameterFull p) =>
 packer chainId' address' xs = either
     (error . fromString . show)
     (\case {Identity ys :& RNil -> ys})
-    $ interpretLorentzInstr env (GenericMultisig.packWithChainId @key @a @_ @_ @'[] @p) (Identity xs :& RNil)
+    $ interpretLorentzInstr env (GenericMultisig.packWithChainId @key @_ @'[] @p) (Identity xs :& RNil)
   where
     env = dummyContractEnv { ceSelf = address', ceChainId = chainId' }
 


### PR DESCRIPTION
Currently, Tez sent to the specialized multisig will be locked.

This prevents the issue by:
- Rejecting all Tez sent to to the specialized multisig
- Clarifying the error message when Tez is sent

The readme is not up to date: it will be updated as part of updating the assets site